### PR TITLE
Bugfix/fix client assets json

### DIFF
--- a/packages/voidjs-cli/CHANGELOG.md
+++ b/packages/voidjs-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # voidjs-cli
 
+## 0.16.1
+
+### Patch Changes
+
+- fix client assets bug
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/voidjs-cli/package.json
+++ b/packages/voidjs-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voidjs-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Manage non-SPA pages with webpack and React.js",
   "main": "dist/voidjs-cli.cjs.js",
   "module": "dist/voidjs-cli.esm.js",

--- a/packages/voidjs-cli/src/ProdBuilder/ClientJsCompiler.ts
+++ b/packages/voidjs-cli/src/ProdBuilder/ClientJsCompiler.ts
@@ -148,7 +148,8 @@ export default class ClientsCompiler {
           filename: '[name].[contenthash].css',
         }),
         new WebpackAssetsManifest({
-          fileName: 'client-assets.json',
+          fileName:
+            relative.replace(/\.client\.(js|ts)$/, '.') + 'client-assets.json',
           generate: generateManifest,
         }),
         new PrettyPlugin(this.#config),

--- a/packages/voidjs-styles/package.json
+++ b/packages/voidjs-styles/package.json
@@ -16,6 +16,6 @@
     "@types/react-dom": "16.9.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "voidjs-cli": "0.16.0"
+    "voidjs-cli": "0.16.1"
   }
 }


### PR DESCRIPTION
We expect multiple `client-assets.json` files when we have multiple client.js files, which is not true at the time.